### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <commons-compress.version>1.4.1</commons-compress.version>
     <quartz.version>2.1.2</quartz.version>
     <postgres.jdbc.version>9.1-901-1.jdbc4</postgres.jdbc.version>
-    <commons-collections>3.2.1</commons-collections>
+    <commons-collections>3.2.2</commons-collections>
     <javax.transaction>1.1</javax.transaction>
     <javax.activation.version>1.1</javax.activation.version>
     <xmlrpc-client.version>3.1.3</xmlrpc-client.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
